### PR TITLE
Update http-proxy-middleware to version 3.0.7

### DIFF
--- a/basic-assignment-2-lisa-solution-3/package-lock.json
+++ b/basic-assignment-2-lisa-solution-3/package-lock.json
@@ -1,4 +1,4 @@
-{
+x{
   "name": "basic-assignment-2-lisa-solution-3",
   "version": "0.1.0",
   "lockfileVersion": 3,
@@ -119,7 +119,7 @@
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.3",
         "esbuild-wasm": "0.28.1",
-        "http-proxy-middleware": "3.0.5",
+        "http-proxy-middleware": "3.0.7",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
         "karma-source-map-support": "1.4.0",
@@ -19780,7 +19780,7 @@
         "connect-history-api-fallback": "^2.0.0",
         "express": "^4.22.1",
         "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.9",
+        "http-proxy-middleware": "3.0.7",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",


### PR DESCRIPTION
Updated http-proxy-middleware version from 3.0.5 to 3.0.7 in package-lock.json.